### PR TITLE
added river temperature modifications

### DIFF
--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -714,6 +714,8 @@ if ($OCN_SGR eq 'data') {
 	add_default($nl, 'config_subglacial_runoff_mode');
 }
 add_default($nl, 'config_flux_attenuation_coefficient_subglacial_runoff');
+add_default($nl, 'config_use_atmospheric_river_temp');
+add_default($nl, 'config_atmospheric_river_temp_max');
 add_default($nl, 'config_sgr_flux_vertical_location');
 add_default($nl, 'config_use_sgr_opt_kpp');
 add_default($nl, 'config_use_sgr_opt_temp_prescribed');

--- a/components/mpas-ocean/bld/build-namelist-section
+++ b/components/mpas-ocean/bld/build-namelist-section
@@ -226,6 +226,8 @@ add_default($nl, 'config_flux_attenuation_coefficient');
 add_default($nl, 'config_flux_attenuation_coefficient_runoff');
 add_default($nl, 'config_subglacial_runoff_mode');
 add_default($nl, 'config_flux_attenuation_coefficient_subglacial_runoff');
+add_default($nl, 'config_use_atmospheric_river_temp');
+add_default($nl, 'config_atmospheric_river_temp_max');
 add_default($nl, 'config_sgr_flux_vertical_location');
 add_default($nl, 'config_use_sgr_opt_kpp');
 add_default($nl, 'config_use_sgr_opt_temp_prescribed');

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -352,6 +352,8 @@
 <config_use_bulk_thickness_flux>.true.</config_use_bulk_thickness_flux>
 <config_flux_attenuation_coefficient>0.001</config_flux_attenuation_coefficient>
 <config_flux_attenuation_coefficient_runoff>10.0</config_flux_attenuation_coefficient_runoff>
+<config_use_atmospheric_river_temp>.false.</config_use_atmospheric_river_temp>
+<config_atmospheric_river_temp_max>30.0</config_atmospheric_river_temp_max>
 <config_subglacial_runoff_mode>'off'</config_subglacial_runoff_mode>
 <config_flux_attenuation_coefficient_subglacial_runoff>0.001</config_flux_attenuation_coefficient_subglacial_runoff>
 <config_sgr_flux_vertical_location>'bottom'</config_sgr_flux_vertical_location>

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -1188,6 +1188,22 @@ Valid values: Any positive real number.
 Default: Defined in namelist_defaults.xml
 </entry>
 
+<entry id="config_use_atmospheric_river_temp" type="logical"
+	category="forcing" group="forcing">
+If true, sets river temperatures equal to the lowest level atmospheric air temperature from coupler. If false, river temperatures are calculated using the nearest neighbor SST.
+
+Valid values: .true. or .false.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_atmospheric_river_temp_max" type="real"
+	category="forcing" group="forcing">
+The maximum atmospheric temperature from coupler used to prescribe river temperatures.
+
+Valid values: Any positive real number.
+Default: Defined in namelist_defaults.xml
+</entry>
+
 <entry id="config_subglacial_runoff_mode" type="char*1024"
 	category="forcing" group="forcing">
 Selects the mode in which subglacial runoff fluxes are implemented.

--- a/components/mpas-ocean/cime_config/buildnml
+++ b/components/mpas-ocean/cime_config/buildnml
@@ -1866,6 +1866,7 @@ def buildnml(case, caseroot, compname):
             lines.append('    <var name="snowFlux"/>')
             lines.append('    <var name="iceFraction"/>')
             lines.append('    <var name="nAccumulatedCoupled"/>')
+            lines.append('    <var name="atmosphericTbot"/>')
             lines.append('</stream>')
             lines.append('')
             lines.append('</streams>')

--- a/components/mpas-ocean/driver/mpaso_cpl_indices.F
+++ b/components/mpas-ocean/driver/mpaso_cpl_indices.F
@@ -75,6 +75,7 @@ module mpaso_cpl_indices
   integer :: index_x2o_Sa_pslv         ! atmospheric sea level pressure   (Pa)
   integer :: index_x2o_Sa_co2prog      ! bottom atm level prognostic CO2
   integer :: index_x2o_Sa_co2diag      ! bottom atm level diagnostic CO2
+  integer :: index_x2o_Sa_tbot         ! bottom atm level temperature     (K)
   integer :: index_x2o_Foxx_taux       ! zonal wind stress (taux)         (W/m2   )
   integer :: index_x2o_Foxx_tauy       ! meridonal wind stress (tauy)     (W/m2   )
   integer :: index_x2o_Foxx_swnet      ! net short-wave heat flux         (W/m2   )
@@ -239,6 +240,7 @@ contains
     index_x2o_Si_ifrac      = mct_avect_indexra(x2o,'Si_ifrac')
     index_x2o_Si_bpress     = mct_avect_indexra(x2o,'Si_bpress')
     index_x2o_Sa_pslv       = mct_avect_indexra(x2o,'Sa_pslv')
+    index_x2o_Sa_tbot       = mct_avect_indexra(x2o,'Sa_tbot')
     index_x2o_So_duu10n     = mct_avect_indexra(x2o,'So_duu10n')
     index_x2o_Foxx_tauy     = mct_avect_indexra(x2o,'Foxx_tauy')
     index_x2o_Foxx_taux     = mct_avect_indexra(x2o,'Foxx_taux')

--- a/components/mpas-ocean/driver/ocn_comp_mct.F
+++ b/components/mpas-ocean/driver/ocn_comp_mct.F
@@ -1749,6 +1749,7 @@ contains
 !    o  duu10n -- 10m wind speed squared                   (m^2/s^2)
 !    o  co2prog-- bottom atm level prognostic co2
 !    o  co2diag-- bottom atm level diagnostic co2
+!    o  tbot -- bottom atm level temperature (K)
 !
 !-----------------------------------------------------------------------
 !
@@ -1821,7 +1822,8 @@ contains
                                   riverRunoffFluxField, iceRunoffFluxField, &
                                   removedRiverRunoffFluxField, removedIceRunoffFluxField, &
                                   shortWaveHeatFluxField, rainFluxField, &
-                                  atmosphericPressureField, iceFractionField, &
+                                  atmosphericPressureField, atmosphericTbotField, &
+                                  iceFractionField, &
                                   seaIcePressureField, windSpeedSquared10mField, &
                                   atmosphericCO2Field, atmosphericCO2_ALT_CO2Field,  &
                                   iceFluxDICField, &
@@ -1871,7 +1873,8 @@ contains
                                                riverRunoffFlux, iceRunoffFlux, &
                                                removedRiverRunoffFlux, removedIceRunoffFlux, &
                                                shortWaveHeatFlux, rainFlux, &
-                                               atmosphericPressure, iceFraction, &
+                                               atmosphericPressure, atmosphericTbot, &  
+                                               iceFraction, &
                                                seaIcePressure, windSpeedSquared10m, &
                                                atmosphericCO2, atmosphericCO2_ALT_CO2,  &
                                                windSpeedSquared10mCFC, &
@@ -1979,6 +1982,7 @@ contains
       call mpas_pool_get_field(forcingPool, 'shortWaveHeatFlux', shortWaveHeatFluxField)
       call mpas_pool_get_field(forcingPool, 'rainFlux', rainFluxField)
       call mpas_pool_get_field(forcingPool, 'atmosphericPressure', atmosphericPressureField)
+      call mpas_pool_get_field(forcingPool, 'atmosphericTbot', atmosphericTbotField)
       call mpas_pool_get_field(forcingPool, 'seaIcePressure', seaIcePressureField)
       call mpas_pool_get_field(forcingPool, 'iceFraction', iceFractionField)
       call mpas_pool_get_field(forcingPool, 'iceRunoffFlux', iceRunoffFluxField)
@@ -2020,6 +2024,7 @@ contains
       shortWaveHeatFlux => shortWaveHeatFluxField % array
       rainFlux => rainFluxField % array
       atmosphericPressure => atmosphericPressureField % array
+      atmosphericTbot => atmosphericTbotField % array
       seaIcePressure => seaIcePressureField % array
       iceFraction => iceFractionField % array
       iceRunoffFlux => iceRunoffFluxField % array
@@ -2213,6 +2218,10 @@ contains
         end if
         if ( atmosphericPressureField % isActive ) then
            atmosphericPressure(i) = x2o_o % rAttr(index_x2o_Sa_pslv,   n)
+        end if
+        if ( atmosphericTbotField % isActive ) then
+           ! Convert from K to C
+           atmosphericTbot(i) = (x2o_o % rAttr(index_x2o_Sa_tbot, n) - 273.15_RKIND)
         end if
         if ( seaIcePressureField % isActive ) then
            ! Set seaIcePressure to be limited to 5m of pressure
@@ -2538,6 +2547,9 @@ contains
    end if
    if ( atmosphericPressureField % isActive ) then
       call mpas_dmpar_exch_halo_field(atmosphericPressureField)
+   end if
+   if ( atmosphericTbotField % isActive ) then
+      call mpas_dmpar_exch_halo_field(atmosphericTbotField)
    end if
    if ( seaIcePressureField % isActive ) then
       call mpas_dmpar_exch_halo_field(seaIcePressureField)
@@ -3264,7 +3276,6 @@ contains
 !    o  duu10n -- 10m wind speed squared                   (m^2/s^2)
 !    o  co2prog-- bottom atm level prognostic co2
 !    o  co2diag-- bottom atm level diagnostic co2
-!
 !-----------------------------------------------------------------------
 !
 ! !REVISION HISTORY:

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -713,6 +713,14 @@
 					description="The length scale of exponential decay of subglacial runoff, used when config_sgr_flux_vertical_location is 'top' or 'bottom'. Fluxes are multiplied by $e^{z/\gamma}$, where this coefficient is $\gamma$."
 					possible_values="Any positive real number."
 		/>
+		<nml_option name="config_use_atmospheric_river_temp" type="logical" default_value=".false."
+					description="If true, sets river temperatures equal to the lowest level atmospheric air temperature from coupler. If false, river temperatures are calculated using the nearest neighbor SST."
+					possible_values=".true. or .false."
+		/>
+		<nml_option name="config_atmospheric_river_temp_max" type="real" default_value="30.0" units="C"
+					description="The maximum atmospheric temperature from coupler used to prescribe river temperatures."
+					possible_values="Any positive real number."
+		/>
 		<nml_option name="config_sgr_flux_vertical_location" type="character" default_value="bottom"
 					description="Selects the vertical location where subglacial runoff is fluxed."
 					possible_values="'top','uniform', 'bottom'"
@@ -1707,7 +1715,6 @@
 		<package name="timeVaryingAtmosphericForcingPKG" description="This package includes variables required for time varying atmospheric forcing"/>
 		<package name="timeVaryingLandIceForcingPKG" description="This package includes variavles required for time varying land-ice forcing"/>
 		<package name="variableShortwave" description="This package includes variables required to compute spatially variable shortwave extinction coefficients"/>
-
 		<package name="splitTimeIntegrator" description="This package includes variables required for either the split or unsplit explicit time integrators."/>
 		<package name="splitAB2TimeIntegrator" description="This package includes variables required for the split explicit AB2 time integrators."/>
 		<package name="semiImplicitTimePKG" description="This package includes variables required for split-implicit time integrators."/>
@@ -3813,7 +3820,6 @@
 		<var name="icebergTemperatureFlux" type="real" dimensions="nCells Time" units="C m s^-1"
 			 description="Heat flux associated with iceberg melt at cell centers sent to coupler. Positive into the ocean."
 		/>
-
 		<var name="totalFreshWaterTemperatureFlux" type="real" dimensions="nCells Time" units="C m s^-1"
 			 description="Sum of heat fluxes associated with water fluxes cell centers sent to coupler. Positive into the ocean."
 		/>
@@ -3836,6 +3842,9 @@
 		<var name="riverRunoffFlux" type="real" dimensions="nCells Time" units="kg m^-2 s^-1"
 			 description="Fresh water flux from river runoff at cell centers from coupler. Positive into the ocean."
 			 packages="thicknessBulkPKG"
+		/>
+   		<var name="atmosphericTbot" type="real" dimensions="nCells Time" units="C"
+			 description="Temperature at the lowest atmospheric level from coupler."
 		/>
 		<var name="subglacialRunoffFlux" type="real" dimensions="nCells Time" units="kg m^-2 s^-1"
 			 description="Fresh water flux from subglacial runoff at cell centers from ice sheet model. Positive into the ocean."

--- a/components/mpas-ocean/src/shared/mpas_ocn_surface_bulk_forcing.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_surface_bulk_forcing.F
@@ -604,7 +604,8 @@ contains
       type(mpas_pool_type),pointer :: tracersSurfaceFluxPool
 
       real (kind=RKIND), dimension(:), pointer :: latentHeatFlux, sensibleHeatFlux, longWaveHeatFluxUp, longWaveHeatFluxDown, &
-                                                  seaIceHeatFlux, icebergHeatFlux, evaporationFlux, riverRunoffFlux
+                                                  seaIceHeatFlux, icebergHeatFlux, evaporationFlux, riverRunoffFlux, &
+                                                  atmosphericTbot
       real (kind=RKIND), dimension(:), pointer :: seaIceFreshWaterFlux, icebergFreshWaterFlux, seaIceSalinityFlux, iceRunoffFlux
       real (kind=RKIND), dimension(:), pointer :: shortWaveHeatFlux, penetrativeTemperatureFlux
       real (kind=RKIND), dimension(:), pointer :: snowFlux, rainFlux
@@ -639,7 +640,8 @@ contains
       call mpas_pool_get_array(forcingPool, 'snowFlux', snowFlux)
       call mpas_pool_get_array(forcingPool, 'shortWaveHeatFlux', shortWaveHeatFlux)
       call mpas_pool_get_array(forcingPool, 'evaporationFlux', evaporationFlux)
-
+      call mpas_pool_get_array(forcingPool, 'atmosphericTbot', atmosphericTbot)
+      
       call mpas_pool_get_array(forcingPool, 'seaIceFreshWaterFlux', seaIceFreshWaterFlux)
       call mpas_pool_get_array(forcingPool, 'icebergFreshWaterFlux', icebergFreshWaterFlux)
       call mpas_pool_get_array(forcingPool, 'seaIceSalinityFlux', seaIceSalinityFlux)
@@ -703,13 +705,21 @@ contains
            ! Accumulate fluxes that use the surface temperature
            rainTemperatureFlux(iCell) = rainFlux(iCell) * tracerGroup(index_temperature_flux,minLevelCell(iCell),iCell) / rho_sw
            evapTemperatureFlux(iCell) = evaporationFlux(iCell) * tracerGroup(index_temperature_flux,minLevelCell(iCell),iCell) / rho_sw
-
-           ! Runoff can only have a minimum temperature of 0.0C, since it is fresh water.
-           tracersSurfaceFluxRunoff(index_temperature_flux,iCell) = riverRunoffFlux(iCell) &
-                      * max(tracerGroup(index_temperature_flux,minLevelCell(iCell),iCell), 0.0_RKIND) / rho_sw
-
+           
+           if ( config_use_atmospheric_river_temp ) then
+               ! Set runoff temperatures to lowest level atmospheric air temperature with a max prescribed by 
+               ! config_atmospheric_river_temp_max. 
+               ! Runoff can only have a minimum temperature of 0.0C, since it is fresh water.
+               tracersSurfaceFluxRunoff(index_temperature_flux,iCell) = riverRunoffFlux(iCell) &
+                      * min( max(atmosphericTbot(iCell), 0.0_RKIND), config_atmospheric_river_temp_max) / rho_sw
+           else 
+               ! Set temperature to nearest neighbor SST
+               tracersSurfaceFluxRunoff(index_temperature_flux,iCell) = riverRunoffFlux(iCell) &
+                       * max(tracerGroup(index_temperature_flux,minLevelCell(iCell),iCell), 0.0_RKIND) / rho_sw
+           endif
+           
            ! Accumulate fluxes that use the freezing point
-! mrp performance note: should call ocn_freezing_temperature just once here
+           ! mrp performance note: should call ocn_freezing_temperature just once here
            seaIceTemperatureFlux(iCell) = seaIceFreshWaterFlux(iCell) * &
                ocn_freezing_temperature( tracerGroup(index_salinity_flux, minLevelCell(iCell), iCell), pressure=0.0_RKIND, &
                                          inLandIceCavity=.false.) / rho_sw

--- a/driver-mct/shr/seq_flds_mod.F90
+++ b/driver-mct/shr/seq_flds_mod.F90
@@ -718,6 +718,7 @@ contains
        call seq_flds_add(a2x_states_to_rof,"Sa_tbot")
     endif
     call seq_flds_add(x2w_states,"Sa_tbot")
+    call seq_flds_add(x2o_states,"Sa_tbot")
     longname = 'Temperature at the lowest model level'
     stdname  = 'air_temperature'
     units    = 'K'

--- a/driver-moab/shr/seq_flds_mod.F90
+++ b/driver-moab/shr/seq_flds_mod.F90
@@ -733,7 +733,8 @@ contains
        call seq_flds_add(x2r_states,"Sa_tbot")
        call seq_flds_add(a2x_states_to_rof,"Sa_tbot")
     endif
-    call seq_flds_add(x2w_states,"Sa_tbot")
+    call seq_flds_add(x2w_states,"Sa_tbot") 
+    call seq_flds_add(x2o_states,"Sa_tbot")
     longname = 'Temperature at the lowest model level'
     stdname  = 'air_temperature'
     units    = 'K'


### PR DESCRIPTION
Adds a stealth feature to set temperatures of incoming river runoff fluxes to bottom-level atmospheric air temperature instead of nearest neighbor SST. 

Rationale/Background: In an 1.5 km resolution G case of the Gulf of Mexico (GoM1pt5) with specially modified river spreading, the default approach of using nearest neighbor SSTs can produce spuriously high temperatures at the river inflow points (see attached). The mesh has 1 m minimum layer thickness and 5 m minimum water depth. The exact cause of the bug is unclear and cannot be fixed by using a very small (1-10 sec) baroclinic timestep, large horizontal mixing, or increasing the background vertical diffusion of tracers (if KPP related). 
![E3SM_ROMS_SST](https://github.com/user-attachments/assets/e6fa0ec8-0a78-4c36-a91e-504655feb40d)

Summary of changes: if ```config_use_atmospheric_river_temp=.true.```, ```components/mpas-ocean/src/shared/mpas_ocn_surface_bulk_forcing.F``` sets incoming river runoff flux temperatures to the atmospheric temperature (in C) ```atmosphericTbot``` from the coupler. The minimum temperature is 0C (for freshwater) and the max is prescribed by ```config_atmospheric_river_temp_max```, which is set to a default value of 30C to prevent the model from running too hot. 30C is the max of most river temperatures in the northern GoM based on >20 years of analysis of the largest 9 regional rivers. Finally, ```atmsophericTbot``` is added to the forcing component of ```components/mpas-ocean/cime_config/buildnml``` so the user can view differences between river temperatures and ambient SST. 

Intention/Caveats: Intended for G cases. Serves as a medium-term solution for GoM1pt5 and future meshes focused on submesoscale coastal dynamics for ICoM and seahorçe. The long-term solution would be to fix the (unknown) cause of the spurious temperatures. Likely inaccurate for polar regions. Maybe we should add a latitudinal bound (60 N/S)?

Testing: Shown below for SMS QU240. A challenge for testing is that the bug only appears in GoM1pt5, so doing long term tests to show differences is expensive (runs on 40 nodes, ~0.4 SYPD). 
```
./create_test SMS_Ld3.T62_oQU240.GMPAS-NYF.chicoma-gpu_gnu -p t25_coastal_ocean_g --walltime 00:30:00
create_test will do up to 1 tasks simultaneously
create_test will use up to 160 cores simultaneously
Creating test directory /lustre/scratch5/dschlichting/E3SM/scratch/chicoma-gpu/SMS_Ld3.T62_oQU240.GMPAS-NYF.chicoma-gpu_gnu.20250115_091140_btel44
RUNNING TESTS:
  SMS_Ld3.T62_oQU240.GMPAS-NYF.chicoma-gpu_gnu
Starting CREATE_NEWCASE for test SMS_Ld3.T62_oQU240.GMPAS-NYF.chicoma-gpu_gnu with 1 procs
Finished CREATE_NEWCASE for test SMS_Ld3.T62_oQU240.GMPAS-NYF.chicoma-gpu_gnu in 2.040820 seconds (PASS)
Starting XML for test SMS_Ld3.T62_oQU240.GMPAS-NYF.chicoma-gpu_gnu with 1 procs
Finished XML for test SMS_Ld3.T62_oQU240.GMPAS-NYF.chicoma-gpu_gnu in 0.679047 seconds (PASS)
Starting SETUP for test SMS_Ld3.T62_oQU240.GMPAS-NYF.chicoma-gpu_gnu with 1 procs
Finished SETUP for test SMS_Ld3.T62_oQU240.GMPAS-NYF.chicoma-gpu_gnu in 10.985263 seconds (PASS)
Starting SHAREDLIB_BUILD for test SMS_Ld3.T62_oQU240.GMPAS-NYF.chicoma-gpu_gnu with 1 procs
Finished SHAREDLIB_BUILD for test SMS_Ld3.T62_oQU240.GMPAS-NYF.chicoma-gpu_gnu in 150.076864 seconds (PASS)
Starting MODEL_BUILD for test SMS_Ld3.T62_oQU240.GMPAS-NYF.chicoma-gpu_gnu with 7 procs
Finished MODEL_BUILD for test SMS_Ld3.T62_oQU240.GMPAS-NYF.chicoma-gpu_gnu in 357.764826 seconds (PASS)
Starting RUN for test SMS_Ld3.T62_oQU240.GMPAS-NYF.chicoma-gpu_gnu with 1 proc on interactive node and 64 procs on compute nodes
Finished RUN for test SMS_Ld3.T62_oQU240.GMPAS-NYF.chicoma-gpu_gnu in 5.520647 seconds (PEND). [COMPLETED 1 of 1]
Waiting for tests to finish
PEND SMS_Ld3.T62_oQU240.GMPAS-NYF.chicoma-gpu_gnu (phase RUN has not yet completed)
    Case dir: /lustre/scratch5/dschlichting/E3SM/scratch/chicoma-gpu/SMS_Ld3.T62_oQU240.GMPAS-NYF.chicoma-gpu_gnu.20250115_091140_btel44
Due to presence of batch system, create_test will exit before tests are complete.
To force create_test to wait for full completion, use --wait
test-scheduler took 527.6207122802734 seconds
```
To show the stealth feature works, we can go to the casedir:
```
cd /lustre/scratch5/dschlichting/E3SM/scratch/chicoma-gpu/SMS_Ld3.T62_oQU240.GMPAS-NYF.chicoma-gpu_gnu.20250115_091140_btel44/run/mpaso_in

161 &forcing
162  config_atmospheric_river_temp_max = 30.0
170  config_use_atmospheric_river_temp = .false.
```
Not shown here, I added print statements to 
```components/mpas-ocean/src/shared/mpas_ocn_surface_bulk_forcing.F```, then did two tests to confirm the if statement works as intended.  
```
709            if ( config_use_atmospheric_river_temp ) then
710                ! Set runoff temperatures to lowest level atmospheric air temperature with a max prescribed by 
711                ! config_atmospheric_river_temp_max. 
712                ! Runoff can only have a minimum temperature of 0.0C, since it is fresh water.
713                tracersSurfaceFluxRunoff(index_temperature_flux,iCell) = riverRunoffFlux(iCell) &
714                       * min( max(atmosphericTbot(iCell), 0.0_RKIND), config_atmospheric_river_temp_max) / rho_sw
715                 print *, 'River temp based on air temps: ', tracersSurfaceFluxRunoff(index_temperature_flux,iCell) 
716            else 
717                ! Set temperature to nearest neighbor SST
718                tracersSurfaceFluxRunoff(index_temperature_flux,iCell) = riverRunoffFlux(iCell) &
719                        * max(tracerGroup(index_temperature_flux,minLevelCell(iCell),iCell), 0.0_RKIND) / rho_sw
720                print *, 'River temp based on SST is: ', tracersSurfaceFluxRunoff(index_temperature_flux,iCell)
721            endif
```