### PR TITLE
adds custom river fluxes

### DIFF
--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -720,6 +720,11 @@ add_default($nl, 'config_use_sgr_opt_temp_prescribed');
 add_default($nl, 'config_use_sgr_opt_salt_prescribed');
 add_default($nl, 'config_sgr_temperature_prescribed');
 add_default($nl, 'config_sgr_salinity_prescribed');
+add_default($nl, 'config_use_custom_river_fluxes');
+add_default($nl, 'config_custom_river_fluxes_lower_latitude');
+add_default($nl, 'config_custom_river_fluxes_left_longitude');
+add_default($nl, 'config_custom_river_fluxes_upper_latitude');
+add_default($nl, 'config_custom_river_fluxes_right_longitude');
 
 ############################
 # Namelist group: coupling #

--- a/components/mpas-ocean/bld/build-namelist-section
+++ b/components/mpas-ocean/bld/build-namelist-section
@@ -232,6 +232,11 @@ add_default($nl, 'config_use_sgr_opt_temp_prescribed');
 add_default($nl, 'config_use_sgr_opt_salt_prescribed');
 add_default($nl, 'config_sgr_temperature_prescribed');
 add_default($nl, 'config_sgr_salinity_prescribed');
+add_default($nl, 'config_use_custom_river_fluxes');
+add_default($nl, 'config_custom_river_fluxes_lower_latitude');
+add_default($nl, 'config_custom_river_fluxes_left_longitude');
+add_default($nl, 'config_custom_river_fluxes_upper_latitude');
+add_default($nl, 'config_custom_river_fluxes_right_longitude');
 
 ############################
 # Namelist group: coupling #

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -360,7 +360,12 @@
 <config_use_sgr_opt_salt_prescribed>.false.</config_use_sgr_opt_salt_prescribed>
 <config_sgr_temperature_prescribed>0.0</config_sgr_temperature_prescribed>
 <config_sgr_salinity_prescribed>0.0</config_sgr_salinity_prescribed>
-
+<config_use_custom_river_fluxes>.false.</config_use_custom_river_fluxes>
+<config_custom_river_fluxes_lower_latitude>0.0</config_custom_river_fluxes_lower_latitude>
+<config_custom_river_fluxes_left_longitude>0.0</config_custom_river_fluxes_left_longitude>
+<config_custom_river_fluxes_upper_latitude>0.0</config_custom_river_fluxes_upper_latitude>
+<config_custom_river_fluxes_right_longitude>0.0</config_custom_river_fluxes_right_longitude>
+    
 <!-- coupling -->
 <config_remove_ais_river_runoff>.false.</config_remove_ais_river_runoff>
 <config_remove_ais_ice_runoff>.false.</config_remove_ais_ice_runoff>

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -1252,6 +1252,54 @@ Valid values: Any positive real number
 Default: Defined in namelist_defaults.xml
 </entry>
 
+<entry id="config_use_sgr_opt_salt_prescribed" type="logical"
+	category="forcing" group="forcing">
+If true, subglacial runoff salinity is set to config_sgr_salinity_prescribed. If false, the salinity is set to 0 PSU.
+
+Valid values: .true. or .false.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_use_custom_river_fluxes" type="logical"
+	category="forcing" group="forcing">
+If true, replace riverRunoffFlux from the coupeler over a prescribed box.
+
+Valid values: .true. or .false.
+Default: Defined in namelist_defaults.xml
+</entry>
+    
+<entry id="config_custom_river_fluxes_lower_latitude" type="real"
+       category="forcing" group="forcing">
+The lower latitude bound of prescribed river volume fluxes.
+ 
+Valid Values: Any number -pi/2 to pi/2 (-90 to 90 degrees)
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_custom_river_fluxes_upper_latitude" type="real"
+       category="forcing" group="forcing">
+The upper latitude bound of prescribed river volume fluxes.
+ 
+Valid Values: Any number -pi/2 to pi/2 (-90 to 90 degrees)
+Default: Defined in namelist_defaults.xml
+</entry>
+ 
+<entry id="config_custom_river_fluxes_right_longitude" type="real"
+       category="forcing" group="forcing">
+The right longitude bound of prescribed river volume fluxes.
+
+Valid Values: Any number 0 to 2*pi (0 to 360 degrees)
+Default: Defined in namelist_defaults.xml
+</entry>
+ 
+<entry id="config_custom_river_fluxes_left_longitude" type="real"
+       category="forcing" group="forcing">
+The left longitude bound of prescribed river volume fluxes.
+ 
+Valid Values: Any number0 to 2*pi (0 to 360 degrees)
+Default: Defined in namelist_defaults.xml
+</entry>
+
 
 <!-- coupling -->
 

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -1252,14 +1252,6 @@ Valid values: Any positive real number
 Default: Defined in namelist_defaults.xml
 </entry>
 
-<entry id="config_use_sgr_opt_salt_prescribed" type="logical"
-	category="forcing" group="forcing">
-If true, subglacial runoff salinity is set to config_sgr_salinity_prescribed. If false, the salinity is set to 0 PSU.
-
-Valid values: .true. or .false.
-Default: Defined in namelist_defaults.xml
-</entry>
-
 <entry id="config_use_custom_river_fluxes" type="logical"
 	category="forcing" group="forcing">
 If true, replace riverRunoffFlux from the coupeler over a prescribed box.

--- a/components/mpas-ocean/driver/ocn_comp_mct.F
+++ b/components/mpas-ocean/driver/ocn_comp_mct.F
@@ -1790,14 +1790,20 @@ contains
                        config_use_CFCTracers,  &
                        config_remove_ais_river_runoff, &
                        config_remove_ais_ice_runoff, &
-                       config_cvmix_kpp_use_theory_wave
+                       config_cvmix_kpp_use_theory_wave, & 
+                       config_use_custom_river_fluxes
 
    character(len=StrKIND), pointer :: config_ecosys_atm_co2_option, &
                                       config_ecosys_atm_alt_co2_option
 
    real (kind=RKIND), pointer :: config_ecosys_atm_co2_constant_value
 
-   real (kind=RKIND), pointer :: config_density0
+   real (kind=RKIND), pointer :: config_density0, &
+                                 config_custom_river_fluxes_lower_latitude, &
+                                 config_custom_river_fluxes_left_longitude, &
+                                 config_custom_river_fluxes_upper_latitude, &
+                                 config_custom_river_fluxes_right_longitude
+                                   
 
    type (block_type), pointer :: block_ptr
 
@@ -1868,7 +1874,7 @@ contains
                                                evaporationFlux, seaIceHeatFlux, icebergHeatFlux, &
                                                snowFlux, seaIceFreshWaterFlux, icebergFreshWaterFlux, &
                                                seaIceSalinityFlux, &
-                                               riverRunoffFlux, iceRunoffFlux, &
+                                               riverRunoffFlux, riverTransport, iceRunoffFlux, &
                                                removedRiverRunoffFlux, removedIceRunoffFlux, &
                                                shortWaveHeatFlux, rainFlux, &
                                                atmosphericPressure, iceFraction, &
@@ -1949,6 +1955,11 @@ contains
    call mpas_pool_get_config(domain % configs, 'config_remove_ais_river_runoff', config_remove_ais_river_runoff)
    call mpas_pool_get_config(domain % configs, 'config_remove_ais_ice_runoff', config_remove_ais_ice_runoff)
    call mpas_pool_get_config(domain % configs, 'config_cvmix_kpp_use_theory_wave', config_cvmix_kpp_use_theory_wave)
+   call mpas_pool_get_config(domain % configs, 'config_use_custom_river_fluxes', config_use_custom_river_fluxes)
+   call mpas_pool_get_config(domain % configs, 'config_custom_river_fluxes_lower_latitude', config_custom_river_fluxes_lower_latitude)
+   call mpas_pool_get_config(domain % configs, 'config_custom_river_fluxes_left_longitude', config_custom_river_fluxes_left_longitude)
+   call mpas_pool_get_config(domain % configs, 'config_custom_river_fluxes_upper_latitude', config_custom_river_fluxes_upper_latitude)
+   call mpas_pool_get_config(domain % configs, 'config_custom_river_fluxes_right_longitude', config_custom_river_fluxes_right_longitude)
 
    n = 0
    removedRiverRunoffFluxThisProc = 0.0_RKIND
@@ -2039,6 +2050,9 @@ contains
 
       call mpas_pool_get_array(meshPool, 'latCell', latCell)
       call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
+      if (config_use_custom_river_fluxes) then
+          call mpas_pool_get_array(forcingPool, 'riverTransport', riverTransport)
+      end if 
 
       ! BGC fields
       if (config_use_ecosysTracers) then
@@ -2183,6 +2197,16 @@ contains
         end if
         if ( riverRunoffFluxField % isActive ) then
            riverRunoffFlux(i) = x2o_o % rAttr(index_x2o_Foxx_rofl, n)
+           ! If using custom river fluxes, override coupler values, set to zero and replace with values 
+           ! prescribed from netcdf file. Convert from m^3 s^-1 to kg m^-2 s^-1.
+           if (config_use_custom_river_fluxes .and. &
+              latCell(i) > config_custom_river_fluxes_lower_latitude .and. &
+              latCell(i) < config_custom_river_fluxes_upper_latitude .and. &
+              lonCell(i) > config_custom_river_fluxes_left_longitude .and. &
+              lonCell(i) < config_custom_river_fluxes_right_longitude) then
+              riverRunoffFlux(i) = 0.0_RKIND
+              riverRunoffFlux(i) = (riverTransport(i) * rho_sw) / areaCell(i)
+           end if 
            if (config_remove_ais_river_runoff) then
               if (latCell(i) < -1.04719666667_RKIND) then ! 60S in radians
                  removedRiverRunoffFlux(i) = riverRunoffFlux(i)

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -737,7 +737,26 @@
 					description="Prescribed subglacial runoff salinity value, applied when config_use_sgr_opt_salt_prescribed = .true."
 					possible_values="Any positive real number"
 		/>
-
+        <nml_option name="config_use_custom_river_fluxes" type="logical" default_value=".false."
+					description="If true, replace riverRunoffFlux from the coupeler over a prescribed box."
+					possible_values=".true. or .false."
+		/> 
+        <nml_option name="config_custom_river_fluxes_lower_latitude" type="real" default_value="0.0" units="radians"
+                	description="The lower latitude bound of the custom river flux box."
+            	    possible_values="Any real number"
+	    />
+        <nml_option name="config_custom_river_fluxes_upper_latitude" type="real" default_value="0.0" units="radians"
+                	description="The upper latitude bound of the custom river flux box."
+            	    possible_values="Any real number"
+	    />
+        <nml_option name="config_custom_river_fluxes_left_longitude" type="real" default_value="0.0" units="radians"
+                	description="The left longitude bound of the custom river flux box."
+            	    possible_values="Any positive real number"
+	    />
+        <nml_option name="config_custom_river_fluxes_right_longitude" type="real" default_value="0.0" units="radians"
+                	description="The left longitude bound of the custom river flux box."
+            	    possible_values="Any positive real number"
+	    />
 	</nml_record>
 	<nml_record name="time_varying_forcing" mode="init;forward">
 		<nml_option name="config_use_time_varying_atmospheric_forcing" type="logical" default_value=".false."
@@ -3732,6 +3751,9 @@
 			 description="Bottom drag Cd coefficient in cells."
 			 packages="variableBottomDragPKG"
 		/>
+        <var name="riverTransport" type="real" dimensions="nCells Time" units="m^3 s^-1" name_in_code="riverTransport"
+             description="Fresh water volume flux from river runoff at cell centers from time varying data."
+        />
 		<var name="nForcingGroupCounter"		type="integer"	dimensions="Time"/>
 		<var name="forcingGroupNames"			type="text"	dimensions="nForcingGroupsMax Time"/>
 		<var name="forcingGroupRestartTimes"		type="text"	dimensions="nForcingGroupsMax Time"/>


### PR DESCRIPTION
Adds a stealth feature to override ```riverRunoffFlux``` from the coupler in a prescribed lat/lon box. If activated, ```riverRunoffFlux``` is set to zero in the box and replaced with values from an external netcdf4 file. As shown below, the user supplies volume fluxes (```riverTransport```) on a per cell basis to ```streams.ocean``` at run time. Volume fluxes are converted to kg m^-2 s^-1 online. Modifications are done in ```ocn_comp_mct.F``` before fluxes are imported to other modules. Intended for G cases, but I *think* this will work for fully coupled simulations (needs verification).

### Context
In the 1.5 km Gulf of Mexico Regionally Refined Mesh (GoMRRM), G case simulations do not have realistic amounts of freshwater from the Atchafalaya River. The JRA river forcing doesn't account for anthropogenic hydraulic controls that divert ~1/3 of the freshwater from the Miss. to Atchafalaya Bay. As a result, a submesoscale eddy field does not form. Another option  to solve this problem is to modify the JRA river files, but the external spreading files make it difficult to know how fluxes are changed at the grid scale *before* running the model. This approach is much more practical for larger meshes because the fluxes are known before run time, as commonly done in regional scale models like ROMS. 

### Testing & use case 

Perlmutter QU240, override coupler fluxes for the Texas-Louisiana shelf in the northern GoM.

Add a print statement to ```ocn_comp_mct.F``` for validation:
```
        if ( riverRunoffFluxField % isActive ) then
           riverRunoffFlux(i) = x2o_o % rAttr(index_x2o_Foxx_rofl, n)
           ! If using custom river fluxes, override coupler values, set to zero and replace with values 
           ! prescribed from netcdf file. Convert from m^3 s^-1 to kg m^-2 s^-1.
           if (config_use_custom_river_fluxes .and. &
              latCell(i) > config_custom_river_fluxes_lower_latitude .and. &
              latCell(i) < config_custom_river_fluxes_upper_latitude .and. &
              lonCell(i) > config_custom_river_fluxes_left_longitude .and. &
              lonCell(i) < config_custom_river_fluxes_right_longitude) then
              riverRunoffFlux(i) = 0.0_RKIND
              riverRunoffFlux(i) = (riverTransport(i) * rho_sw) / areaCell(i)
              print *, 'Reassigning TXLA river runoff flux to ', riverRunoffFlux(i)
```
Create the test: 
``` 
./create_test SMS_Ld3.T62_oQU240.GMPAS-NYF.pm-cpu_gnu -p m4304 --walltime 00:30:00
```
Go to casedir to switch on stealth feature: 
```
# Modify user_nl_mpaso
config_use_custom_river_fluxes = .true.
config_custom_river_fluxes_left_longitude = 4.56891948
config_custom_river_fluxes_lower_latitude = 0.40039961
config_custom_river_fluxes_right_longitude = 4.73856892
config_custom_river_fluxes_upper_latitude = 0.5386048

# Modify streams.ocean
cp run/streams.ocean SourceMods/src.mpaso/streams.ocean

# Add the following
<stream name="river_forcing"
    type="input"
    filename_template="river_forcing.nc"
    reference_time="0001-01-01_00:00:00"
    io_type="netcdf4"
    input_interval="0001_00:00:00">

  <var name="riverTransport"/>
  <var name="xtime"/>
</stream>
```
Now, create some toy ```riverTransport``` data in the rundir:
```
# Cleaned up by chatgpt
import numpy as np
from netCDF4 import Dataset
from datetime import datetime, timedelta

# Set the dimensions. nCells determined from QU240 mesh size.
nCells = 7153
Time = 365
StrLen = 64

def remove_spaces_keep_dimension(text, placeholder=' '):
    """
    Replaces all spaces in a string with a specified placeholder character, 
    maintaining the original length of the string.

    Args:
        text (str): The input string.
        placeholder (str, optional): The character to use as a placeholder. Defaults to a space.

    Returns:
        str: The modified string with spaces replaced by placeholders.
    """
    return text.replace(' ', placeholder)

def process_list_of_strings(string_list, placeholder=' '):
    """
    Applies `remove_spaces_keep_dimension` to a list of strings.

    Args:
        string_list (list): List of input strings.
        placeholder (str, optional): The character to use as a placeholder. Defaults to a space.

    Returns:
        list: A list of modified strings with spaces replaced by placeholders.
    """
    return [remove_spaces_keep_dimension(text, placeholder) for text in string_list]

# Create the NetCDF file
with Dataset('river_forcing.nc', 'w', format='NETCDF4') as f:
    # Define dimensions
    f.createDimension('Time', None)
    f.createDimension('nCells', nCells)
    f.createDimension('StrLen', StrLen)

    time_var = f.createVariable('TIME', 'f8', ('Time',))
    time_var[:] = np.arange(Time)  # Set time values to 0, 1, ..., 364
    time_var.setncattr('units', "DAYS")
    time_var.setncattr('time_origin', "01-JAN-0001 00:00:00")
    time_var.setncattr('calendar', "NOLEAP")
    time_var.setncattr('modulo', 365.0)
    time_var.setncattr('axis', "T")

    # Starting date: 0001-01-01 00:00:00
    start_date = datetime(1, 1, 1, 0, 0, 0)
    # Create the xtime variable (character array)
    xtime = f.createVariable('xtime', 'S1', ('Time', 'StrLen'))  # 'S1' is the dtype for string
    # Generate xtime values (strings in format: YYYY-MM-DD HH:MM:SS)
    xtime[:] = np.array([list((start_date + timedelta(days=i)).strftime('%04Y-%m-%d_%H:%M:%S').ljust(StrLen)) for i in range(Time)], dtype='S1')

    # Create variables
    fill_value=1.0e30
    riverTransport = f.createVariable('riverTransport', 'f8', 
                                      ('Time', 'nCells'),
                                      fill_value=fill_value)
    riverTransport[:,:] = 1  # Set all values to 1 for all nCells
    # Increase slightly w.r.t. time so we can see temporal variability in the log file
    for j in range(Time):
        riverTransport[j,:] = j+0.8  # integer day +0.8
    riverTransport.setncattr('long_name', "River volume fluxes")
    riverTransport.setncattr('units', "m^3 s^-1")
```
Verify file metadata:
```
ncdump -v riverTransport river_forcing.nc | head -n 100
netcdf river_forcing {
dimensions:
        Time = UNLIMITED ; // (365 currently)
        nCells = 7153 ;
        StrLen = 64 ;
variables:
        double TIME(Time) ;
                TIME:units = "DAYS" ;
                TIME:time_origin = "01-JAN-0001 00:00:00" ;
                TIME:calendar = "NOLEAP" ;
                TIME:modulo = 365. ;
                TIME:axis = "T" ;
        char xtime(Time, StrLen) ;
        double riverTransport(Time, nCells) ;
                riverTransport:_FillValue = 1.e+30 ;
                riverTransport:long_name = "River volume fluxes" ;
                riverTransport:units = "m^3 s^-1" ;
data:

 riverTransport =
  0.8, 0.8, 0.8, 0.8, .... 1.8, 1.8, 1.8, 1.8, 1.8 .... 2.8, 2.8, 2.8, 2.8, 2.8
```
Switch back to casedir, then ```./case.submit```. Runs to completion. Important part of ocn log file:
```
cat ocn.log.37796202.250415-121557 | grep river_forcing 

 ----- reading dimensions from stream 'river_forcing' using file river_forcing.nc
        nCells = 7153

 -----  found stream "river_forcing" in streams.ocean  -----
         filename template:  river_forcing.nc
         filename interval:  0001_00:00:00
         I/O type:           NetCDF-4/HDF5
         direction:          input
         reference time:     0001-01-01_00:00:00
         record interval:    -
         input alarm:        0001_00:00:00
```

Check the e3sm log file for validation of print statement:
```
cat e3sm.log.37796202.250415-121557
0:  (t_initf) Read in prof_inparm namelist from: drv_in
  0:  (t_initf) Using profile_disable=          F
  0:  (t_initf)       profile_timer=                      4
  0:  (t_initf)       profile_depth_limit=               20
  0:  (t_initf)       profile_detail_limit=              12
  0:  (t_initf)       profile_barrier=          F
  0:  (t_initf)       profile_outpe_num=                  1
  0:  (t_initf)       profile_outpe_stride=               0
  0:  (t_initf)       profile_single_file=      F
  0:  (t_initf)       profile_global_stats=     T
  0:  (t_initf)       profile_ovhd_measurement= F
  0:  (t_initf)       profile_add_detail=       F
  0:  (t_initf)       profile_papi_enable=      F
 77:  Reassigning TXLA river runoff flux to    1.7702750740937643E-008
 77:  Reassigning TXLA river runoff flux to    1.7787002432386404E-008
 77:  Reassigning TXLA river runoff flux to    1.7205415178613567E-008
 77:  Reassigning TXLA river runoff flux to    1.7783686348066185E-008
 77:  Reassigning TXLA river runoff flux to    1.7451428296627788E-008
 77:  Reassigning TXLA river runoff flux to    1.7370961386329412E-008
 77:  Reassigning TXLA river runoff flux to    1.8152888419473765E-008
 77:  Reassigning TXLA river runoff flux to    1.6996488754856789E-008
 77:  Reassigning TXLA river runoff flux to    1.6973637136178583E-008
 77:  Reassigning TXLA river runoff flux to    1.6994782122780759E-008
 77:  Reassigning TXLA river runoff flux to    1.7187725850661530E-008
 77:  Reassigning TXLA river runoff flux to    1.7205807180929315E-008
 77:  Reassigning TXLA river runoff flux to    1.7462638749873463E-008
  0: PIO: WARNING:  The user buffer used to read the distributed array is not contiguous. A temporary contiguous buffer will be used to read the data, that can negatively impact the I/O performance. varid =           11 , file id =           36, (spio_darray.F90:163)
  0: PIO: WARNING:  The user buffer used to read the distributed array is not contiguous. A temporary contiguous buffer will be used to read the data, that can negatively impact the I/O performance. varid =           12 , file id =           36, (spio_darray.F90:163)
  0: PIO: WARNING:  The user buffer used to read the distributed array is not contiguous. A temporary contiguous buffer will be used to read the data, that can negatively impact the I/O performance. varid =            6 , file id =           37, (spio_darray.F90:163)
  0: PIO: WARNING:  The user buffer used to read the distributed array is not contiguous. A temporary contiguous buffer will be used to read the data, that can negatively impact the I/O performance. varid =            6 , file id =           38, (spio_darray.F90:163)
```
Note the fluxes are different in each cell because ```areaCell``` differs.